### PR TITLE
Update ANONYMITY_NETWORKS.md

### DIFF
--- a/docs/ANONYMITY_NETWORKS.md
+++ b/docs/ANONYMITY_NETWORKS.md
@@ -55,8 +55,8 @@ proxy at IP 127.0.0.1 port 9050 with a max of 10 outgoing connections and
 If desired, peers can be manually specified:
 
 ```
---add-exclusive-node rveahdfho7wo4b2m.onion:28083
---add-peer rveahdfho7wo4b2m.onion:28083
+--add-exclusive-node 5tymba6faziy36md5ffy42vatbjzlye4vyr3gyz6lcvdfximnvwpmwqd.onion:28083
+--add-peer 5tymba6faziy36md5ffy42vatbjzlye4vyr3gyz6lcvdfximnvwpmwqd.onion:28083
 ```
 
 Either option can be listed multiple times, and can specify any mix of Tor,
@@ -70,12 +70,12 @@ Receiving anonymity connections is done through the option
 type, and max connections:
 
 ```
---anonymous-inbound rveahdfho7wo4b2m.onion:28083,127.0.0.1:28083,25
+--anonymous-inbound 5tymba6faziy36md5ffy42vatbjzlye4vyr3gyz6lcvdfximnvwpmwqd.onion:28083,127.0.0.1:28083,25
 --anonymous-inbound cmeua5767mz2q5jsaelk2rxhf67agrwuetaso5dzbenyzwlbkg2q.b32.i2p:5000,127.0.0.1:30000
 ```
 
 which tells `monerod` that a max of 25 inbound Tor connections are being
-received at address "rveahdfho7wo4b2m.onion:28083" and forwarded to `monerod`
+received at address "5tymba6faziy36md5ffy42vatbjzlye4vyr3gyz6lcvdfximnvwpmwqd.onion:28083" and forwarded to `monerod`
 localhost port 28083, and a default max I2P connections are being received at
 address "cmeua5767mz2q5jsaelk2rxhf67agrwuetaso5dzbenyzwlbkg2q.b32.i2p:5000" and
 forwarded to `monerod` localhost port 30000.
@@ -98,7 +98,7 @@ HiddenServicePort 18081 127.0.0.1:18081
 Then the wallet will be configured to use a Tor/i2p address:
 ```
 --proxy 127.0.0.1:9050
---daemon-address rveahdfho7wo4b2m.onion
+--daemon-address 5tymba6faziy36md5ffy42vatbjzlye4vyr3gyz6lcvdfximnvwpmwqd.onion
 ```
 
 The proxy must match the address type - a Tor proxy will not work properly with
@@ -106,7 +106,7 @@ i2p addresses, etc.
 
 i2p and onion addresses provide the information necessary to authenticate and
 encrypt the connection from end-to-end. If desired, SSL can also be applied to
-the connection with `--daemon-address https://rveahdfho7wo4b2m.onion` which
+the connection with `--daemon-address https://5tymba6faziy36md5ffy42vatbjzlye4vyr3gyz6lcvdfximnvwpmwqd.onion` which
 requires a server certificate that is signed by a "root" certificate on the
 machine running the wallet. Alternatively, `--daemon-cert-file` can be used to
 specify a certificate to authenticate the server.
@@ -204,7 +204,7 @@ If a single I2P/Tor stream is used 2+ times for transmitting a transaction, the
 operator of the hidden service can conclude that both transactions came from the
 same source. If the subsequent transactions spend a change output from the
 earlier transactions, this will also reveal the "real" spend in the ring
-signature. This issue was (primarily) raised by @secparam on Twitter.
+signature. This issue was (primarily) raised by @secparam on [Twitter](https://twitter.com/secparam/status/1153411657214910469).
 
 #### Mitigation
 
@@ -219,7 +219,7 @@ most cases. However, the number of outgoing connections is typically a small
 fixed number, so there is a decent probability of re-use with the same public
 key identity.
 
-@secparam (twitter) recommended changing circuits (Tor) as an additional
+@secparam ([Twitter](https://twitter.com/secparam/status/1153411968147042304)) recommended changing circuits (Tor) as an additional
 precaution. This is likely not a good idea - forcibly requesting Tor to change
 circuits is observable by the ISP. Instead, `monerod` should likely disconnect
 from peers occasionally. Tor will rotate circuits every ~10 minutes, so


### PR DESCRIPTION
Removed version 2 onion addresses as they're deprecated from TOR and updated I2P/Tor Stream Used Twice section to reference tweets relevant to section.